### PR TITLE
flesh out reification method to hamt

### DIFF
--- a/reification.go
+++ b/reification.go
@@ -2,6 +2,7 @@ package hamt
 
 import (
 	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 )
 
 // Reify looks at an ipld Node and tries to interpret it as a HAMT;
@@ -14,10 +15,42 @@ import (
 // Other approaches include using the synthetic builder (if you just want to engage at the "build a map" level),
 // or using Schemas to denote where the HAMT should appear (in which case
 // loading data while using the schema should automatically reify the HAMT without further action required).
-func Reify(root ipld.Node) (ipld.Node, error) {
-	panic("TODO")
+func Reify(lnkCtx ipld.LinkContext, maybeHamt ipld.Node, lsys *ipld.LinkSystem) (ipld.Node, error) {
+	n := Node{
+		modeFilecoin:  false,
+		linkSystem:    *lsys,
+		linkPrototype: cidlink.LinkPrototype{},
+	}
+	if lnkCtx.LinkNode != nil {
+		l, err := lnkCtx.LinkNode.AsLink()
+		if err != nil {
+			return nil, err
+		}
+		n.linkPrototype = l.Prototype()
+	}
+
+	// see if node looks like a hamt root:
+	if bs, err := maybeHamt.LookupByString("bucketSize"); err == nil && bs.Kind() == ipld.Kind_Int {
+		hmrb := Type.HashMapRoot__Repr.NewBuilder()
+		if err := hmrb.AssignNode(maybeHamt); err != nil {
+			return nil, err
+		}
+		hmr := hmrb.Build().(*_HashMapRoot)
+		n._HashMapRoot = *hmr
+	} else {
+		n.modeFilecoin = true
+		hmnb := Type.HashMapNode__Repr.NewBuilder()
+		if err := hmnb.AssignNode(maybeHamt); err != nil {
+			return nil, err
+		}
+		hmn := hmnb.Build().(*_HashMapNode)
+		n._HashMapRoot.hamt = *hmn
+	}
+
+	return &n, nil
 }
 
+// Substrate returns the representation of the ADL
 func (n *Node) Substrate() ipld.Node {
 	if n.modeFilecoin {
 		// A Filecoin v3 HAMT is encoded as just the root node, without


### PR DESCRIPTION
Design questions at this point
* Should we always try to fallback to filecoin mode / do we think the 'feature detection' type of switching makes sense?
* Can we late-load filling in the `LinkPrototype` until the first time we encounter a link in the reified dag, or are there cases we may want to update before we do anything that would cause us to see one? Is there a way to get it out of the linksystem defaults in this case?