### PR TITLE
wip: prototyping what hamt amending might look like.

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -96,7 +96,7 @@ func (b *Builder) BeginMap(sizeHint int64) (ipld.MapAssembler, error) {
 		return &assembler{node: b.node}, nil
 	}
 	if b.bitWidth < 3 {
-		return nil, fmt.Errorf("bitWidth must bee at least 3")
+		return nil, fmt.Errorf("bitWidth must be at least 3")
 	}
 	switch b.hashAlg {
 	case multicodec.Identity, multicodec.Sha2_256, multicodec.Murmur3_128:
@@ -111,6 +111,34 @@ func (b *Builder) BeginMap(sizeHint int64) (ipld.MapAssembler, error) {
 		},
 	}
 	return &assembler{node: b.node}, nil
+}
+
+// StartWith is an extension to a NodeBuilder which advertises that it can make
+// new data structures with copy-on-write internal memory.
+//
+// It's particularly impactful for something like this HAMT ADL,
+// since it means an appended data structure can be made without lots of copying,
+// and also no need to re-compute the sharding, bucketing, etc for all that data.
+func (b *Builder) StartWith(n ipld.Node) (ipld.MapAssembler, error)  {
+	// Of course, we can only really do this well if the node you give us is the type we know well.
+	if n2, familiar := n.(*Node); familiar {
+		if b.bitWidth != n2.bitWidth() {
+			panic(fmt.Errorf("todo: fallback to a copy?  distinct bitwidth; %v %v", b.bitWidth, n2.bitWidth()))
+		}
+		//if b.hashAlg != n2.hashAlg() { // FIXME oh dear.  This is not recalled and we cannot check it.  (It would be an impossible claim to verify for something serial, anyway, I suppose.)  That... provokes interesting conversations.
+		//	panic("todo: fallback to a copy?")
+		//}
+		if b.bucketSize != n2._bucketSize() {
+			panic(fmt.Errorf("todo: fallback to a copy?  distinct bucket size; %v %v", b.bucketSize, n2._bucketSize()))
+		}
+		// It's also particularly easy to implement this confidently since the internal data structures are immutable in memory, too.
+		// TODO ^ check if this claim is actually true.  I am not sure it is.  I think I see touching of the innards.
+		// We already have a new Node allocated (we assume) by either NewBuilder or by Reset; we'll just smash the memory of the node we're starting with on top of that, and then we go from there.3
+		*b.node = *n2
+		return &assembler{node: b.node}, nil
+	}
+	panic("todo: fallback to a copy?  not this adl impl at all") // REVIEW what the contract of this should be.  I dislike things that can be "suprise!  slow because of argument misalignment we didn't raise to you".
+	// I suppose if we have a well-typed error for this, we can make the decision about whether to fall back to a dumb copy or not something that the top level IPLD functions can choose (...assuming that we also pursue that thought).
 }
 func (b *Builder) BeginList(sizeHint int64) (ipld.ListAssembler, error) { panic("todo: error?") }
 func (b *Builder) AssignNull() error                                    { panic("todo: error?") }


### PR DESCRIPTION
More for discussion than anything else -- not final functional code.

I started with the idea of a `func (b *Builder) StartWith(n ipld.Node) (ipld.MapAssembler, error)` method -- in other words, something on the type that implements `NodeAssembler` which has a fairly standard signature that we could make feature-detactable through a standard interface -- and just tried to see how that would go.

I think this probably does a large amount of what we'd want.

We could combine this with some kind of `ipld.AmendMap(newMem NodeAssembler, basis Node) (MapAssembler, error)` method in the main IPLD packages (now that we've done [go-ipld-prime#228](https://github.com/ipld/go-ipld-prime/pull/228) and released that in v0.12.0, especially), which will feature-detect this function, or, fall back onto doing a dumb copy and returning an assembler you can continue with in the semantically same way.  This would make the "amend" concept usable universally, but also work efficiently when we have a function like this one implemented.

There's tricky bits relating to verifying whether any are actually matching the existing structure you try to modify, but these are incidentals of this hamt implementation and whether it serializes all its parameters, how we decide to verify that, etc.  Not relevant to the concept of interface generalization, if we're looking for what patterns can be extracted here.