### PR TITLE
Implement map iterator over element links

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,11 @@
+package hamt
+
+import (
+	"errors"
+)
+
+// ErrMalformedHamt is returned whenever a block intended as a HAMT node does
+// not conform to the expected form that a block may take. This can occur
+// during block-load where initial validation takes place or during traversal
+// where certain conditions are expected to be met.
+var ErrMalformedHamt = errors.New("malformed HAMT node")

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipld/go-ipld-prime v0.16.1-0.20220607093021-c88f0b441e80
 	github.com/multiformats/go-multicodec v0.5.0
+	github.com/multiformats/go-multihash v0.1.0
 	github.com/twmb/murmur3 v1.1.6
 	github.com/whyrusleeping/cbor-gen v0.0.0-20220514204315-f29c37e9c44c
 )
@@ -24,7 +25,6 @@ require (
 	github.com/multiformats/go-base32 v0.0.3 // indirect
 	github.com/multiformats/go-base36 v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.0.3 // indirect
-	github.com/multiformats/go-multihash v0.1.0 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e // indirect
 	github.com/rogpeppe/go-internal v1.6.1 // indirect


### PR DESCRIPTION
The map iterator implementation was only handling buckets in the
`Element` unions. This meant that if the length of HAMT is sufficiently
large, such that `Element`s could contain a link to a node, the map
iterator would panic.

To avoid this, load the `Element` link when it is encountered and
populate the iterator steps appropriately so that the entire map is
traversed.

Add tests that assert the map iterator functions as expected: traverses
the entire map, and returns each key exactly once.

Avoid `panic`ing by letting `Done` proceed and retrospectively return
 errors via `Next` as stated in `MapIterator.Done` interface
 documentation.